### PR TITLE
Fixed ResembleJS path bug

### DIFF
--- a/phantomjs/runner.js
+++ b/phantomjs/runner.js
@@ -31,7 +31,7 @@ var phantomcss = require(phantomCSSPath+s+'phantomcss.js');
 phantomcss.init({
     screenshotRoot: args.screenshots,
     failedComparisonsRoot: args.failures,
-    libraryRoot: phantomCSSPath+s+'ResembleJs', // Give absolute path, otherwise PhantomCSS fails
+    libraryRoot: phantomCSSPath, // Give absolute path, otherwise PhantomCSS fails
 
     onFail: function(test) {
         sendMessage('onFail', test);


### PR DESCRIPTION
Huddle/PhantomCSS@7baf330d3203de67fde93271f384190875061bd0 changed the ResembleJS path, causing this task to fail.

This was caused by #8 as the bower dependency was the latest and contained this breaking change.

Thanks to @mrspothawk for spotting this one!
