### PR TITLE
fix(bower): override default directory

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}


### PR DESCRIPTION
`bower install` searches for `.bowerrc` file up the directory tree until
it finds one. If the project overrides the default bower directory (e.g.
projects generated by yeoman change it to "app/bower_components"), the
change will also affect phantomcss and break the relative path.
This commit isolates the phantomcss bower configuration from parent
project.
