### PR TITLE
fix(bower): use a fixed phantomcss version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
     "tests"
   ],
   "dependencies": {
-    "phantomcss": "*"
+    "phantomcss": "f0846511d9e1e55aa160aaab84e2a150bd3a5a41"
   }
 }


### PR DESCRIPTION
Don't rely on whatever is latest in master, this helps avoid breaking changes.
Properly addresses chrisgladd/grunt-phantomcss#8
