### PR TITLE
Allowed multiple runs of phantomjs and still know when to fail grunt

### DIFF
--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -121,7 +121,7 @@ module.exports = function(grunt) {
             onComplete: function(allTests, noOfFails, noOfErrors) {
                 if (allTests.length) {
                     var noOfPasses = allTests.length - failureCount;
-                    failureCount = noOfFails + noOfErrors;
+                    failureCount += noOfFails + noOfErrors;
 
                     if (failureCount === 0) {
                         grunt.log.ok('All ' + noOfPasses + ' tests passed!');


### PR DESCRIPTION
Simple fix for an issue I'm running into where I'm running PhantomCSS multiple times in one grunt task (yes I know I can specify multiple tasks inside grunt, but I need some memory between the tests) and sometimes the first task can fail, and the second one succeed and grunt thinks everything is just fine and dandy. 
