### PR TITLE
Forced diff screenshot deletion to fix a warning

### DIFF
--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
 
             // Delete all of 'em
             diffScreenshots.forEach(function(filepath) {
-                grunt.file.delete(filepath);
+                grunt.file.delete(filepath, { force: true });
             });
         };
 


### PR DESCRIPTION
Fix for warning "Cannot delete files outside the current working directory", that halts the tests.

I've got this warning on Windows. Screens were in test/visual/screenshots directory. Initial and diff screens were created but next time diff screens could not be deleted and the whole process stopped.
