### PR TITLE
Handle random phantomjs crashes

### DIFF
--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -21,7 +21,11 @@ module.exports = function(grunt) {
             screenshots: 'screenshots',
             results: 'results',
             viewportSize: [1280, 800],
-            logLevel: 'error'
+            logLevel: 'error',
+            pageSettings: {
+              loadImages:  false
+            },
+            rebase: false
         });
 
         // Timeout ID for message checking loop
@@ -164,21 +168,37 @@ module.exports = function(grunt) {
         // Start watching for messages
         checkForMessages();
 
-        grunt.util.spawn({
+        //FailSafe PhantomJS
+        var done = this.async();
+        var count = 0;
+        var retry = function () {
+          grunt.util.spawn({
             cmd: phantomBinaryPath,
             args: [
-                runnerPath,
-                JSON.stringify(options)
+              runnerPath,
+              JSON.stringify(options)
             ],
             opts: {
-                cwd: cwd,
-                stdio: 'inherit'
+              cwd: cwd,
+              stdio: 'inherit'
             }
-        }, function(error, result, code) {
-            // When Phantom exits check for remaining messages one last time
-            checkForMessages(true);
+          }, function (error, result, code) {
+            count++;
+            if (error && code === 1 /*error code thrown by when phantomjs fails*/) {
+              if(count < 8) {
+                grunt.log.writeln("Retrying phantomcss tests up to 7 times. Try: " + count);
+                retry();
+              } else {
+                checkForMessages(true);
+                cleanup(error);
+                done(false);
+              }
+            } else {
+              done(result);
+            }
+          });
+        }
+        retry();
 
-            cleanup(error);
-        });
     });
 };

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -21,11 +21,7 @@ module.exports = function(grunt) {
             screenshots: 'screenshots',
             results: 'results',
             viewportSize: [1280, 800],
-            logLevel: 'error',
-            pageSettings: {
-              loadImages:  false
-            },
-            rebase: false
+            logLevel: 'error'
         });
 
         // Timeout ID for message checking loop


### PR DESCRIPTION
On my machine phantomjs crashes occasionally with the message:

````shell
PhantomJS has crashed. Please read the crash reporting guide ...
````
As the reason is sporadic and not preventable, i thought it would be nice to restart the task upon such a crash. 
A general grunt-task fix at
https://github.com/ariya/phantomjs/issues/12325#issuecomment-56246505
helped greatly. I adjusted the task accordingly. 

Works fine now. Though it would be nice to disable phantoms crash-logs beeing saved to /tmp and to catch a more specific error-code.


As this is a [common](http://stackoverflow.com/questions/28108839/phantomjs-crashes-while-running-with-grunt-karma-test-cases) [issue](https://github.com/angular/protractor/issues/557) with phantom i thought you might be interested in including this as a fix.

