### PR TITLE
Directory resolve fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "peerDependencies": {
     "phantomjs-prebuilt": "~2.1.3",
-    "grunt": ">=0.4.5"
+    "grunt": ">=0.4.5",
+    "casperjs": "^1.1.1"
   },
   "keywords": [
     "gruntplugin",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "test": "grunt test",
-    "postinstall": "bower install"
+    "postinstall": "bower install --allow-root"
   },
   "devDependencies": {
     "grunt": ">=0.4.5",

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -9,10 +9,39 @@
 
 var path = require('path');
 var tmp = require('tmp');
+var fs = require('fs');
+
+function resolveDirectory(pathPart, maxLevel) {
+    var pathPrefix = './';
+    var resultPath;
+    for (var i = 0; i < maxLevel; ++i) {
+        var folderPath = path.resolve(pathPrefix + pathPart);
+
+        try {
+            var stats = fs.statSync(folderPath);
+            if (stats.isDirectory()) {
+                resultPath = folderPath;
+                break;
+            }
+        } catch(e) {
+            // just do nothing and try the next path
+        }
+
+        pathPrefix = '../' + pathPrefix;
+    }
+
+    if (!resultPath) {
+        throw new Error('Cannot find ' + pathPart);
+    }
+
+    return resultPath;
+}
+
+
 var phantomBinaryPath = require('phantomjs-prebuilt').path;
 var runnerPath = path.join(__dirname, '..', 'phantomjs', 'runner.js');
-var phantomCSSPath = path.join(__dirname, '..', 'node_modules', 'phantomcss');
-var casperPath = path.join(__dirname, '..', 'node_modules', 'casperjs');
+var phantomCSSPath = resolveDirectory('node_modules/phantomcss', 5);
+var casperPath = resolveDirectory('node_modules/casperjs', 5);
 
 module.exports = function(grunt) {
     grunt.registerMultiTask('phantomcss', 'CSS Regression Testing', function() {

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -12,7 +12,7 @@ var tmp = require('tmp');
 var fs = require('fs');
 
 function resolveDirectory(pathPart, maxLevel) {
-    var pathPrefix = './';
+    var pathPrefix = __dirname + '/';
     var resultPath;
     for (var i = 0; i < maxLevel; ++i) {
         var folderPath = path.resolve(pathPrefix + pathPart);
@@ -27,7 +27,7 @@ function resolveDirectory(pathPart, maxLevel) {
             // just do nothing and try the next path
         }
 
-        pathPrefix = '../' + pathPrefix;
+        pathPrefix += '../';
     }
 
     if (!resultPath) {


### PR DESCRIPTION
At the moment, grunt task doesn't work when you use it via npm. It works only if you clone the repo and run task there. I fixed this and checked with npm@2 and npm@3.
Also, I added casperjs as peer dependency. Because you can't use this plugin without casperjs.
